### PR TITLE
feat: add firefox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+.env
+dist/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ Follow these steps to set up the project on your local machine.
 
 > **Note:** Changes to the source code will only reflect after you reload the extension on the `chrome://extensions/` page.
 
+### Building browser bundles (manifests)
+
+This project includes a small script to generate browser-specific bundles (manifests and assets) into `dist/`.
+
+Run the generator:
+
+```bash
+# generate Chrome bundle
+npm run manifest:chrome
+
+# generate Firefox bundle
+npm run manifest:firefox
+
+# generate both
+npm run manifest:all
+```
+
+The script will copy `icons/` and `src/` into `dist/<browser>/`.
+
 ### Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
     "version": "1.0.0",
     "description": "Turn YouTube playlists into courses. Track your playlist with checkmarks, progress bar, total and watched duration, and completion percentage.",
     "scripts": {
-        "format": "prettier --write ."
+        "format": "prettier --write .",
+           "manifest:chrome": "node scripts/generate-manifest.js chrome",
+           "manifest:firefox": "node scripts/generate-manifest.js firefox",
+           "manifest:all": "node scripts/generate-manifest.js"
     },
     "devDependencies": {
         "prettier": "^3.6.2"

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -1,0 +1,99 @@
+// Script to generate browser-specific manifest.json files and copy assets (icons, src)
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const baseManifest = require(path.join(root, 'manifest.json'));
+
+function safeMkdir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function copyRecursive(src, dest) {
+  try {
+    // fs.cpSync is available in Node 16.7+. Use it when possible for simplicity.
+    if (fs.cpSync) {
+      fs.cpSync(src, dest, { recursive: true });
+      return true;
+    }
+  } catch (e) {
+    // fallthrough to manual copy
+  }
+
+  // Fallback manual copy
+  if (!fs.existsSync(src)) return false;
+  safeMkdir(dest);
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyRecursive(srcPath, destPath);
+    } else if (entry.isSymbolicLink()) {
+      const real = fs.readlinkSync(srcPath);
+      try { fs.symlinkSync(real, destPath); } catch (e) { fs.copyFileSync(srcPath, destPath); }
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+  return true;
+}
+
+function listFilesCount(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  let count = 0;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) count += listFilesCount(p);
+    else count += 1;
+  }
+  return count;
+}
+
+function generateManifestFor(browser) {
+  const manifest = { ...baseManifest };
+  if (browser === 'chrome') {
+    manifest.manifest_version = 3;
+    // chrome-specific tweaks can go here
+  } else if (browser === 'firefox') {
+    // Many Firefox add-ons still accept manifest v2; we intentionally downgrade
+    // to v2 for compatibility if needed. Adjust as required.
+    manifest.manifest_version = 2;
+    manifest.browser_specific_settings = manifest.browser_specific_settings || {};
+    manifest.browser_specific_settings.gecko = manifest.browser_specific_settings.gecko || {
+      id: '',
+      strict_min_version: '57.0'
+    };
+  }
+
+  const outDir = path.join(root, 'dist', browser);
+  safeMkdir(outDir);
+  fs.writeFileSync(path.join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+  // Copy icons and src
+  const iconsSrc = path.join(root, 'icons');
+  const srcSrc = path.join(root, 'src');
+  let copiedIcons = false;
+  let copiedSrc = false;
+  try {
+    if (fs.existsSync(iconsSrc)) {
+      copiedIcons = copyRecursive(iconsSrc, path.join(outDir, 'icons'));
+    }
+    if (fs.existsSync(srcSrc)) {
+      copiedSrc = copyRecursive(srcSrc, path.join(outDir, 'src'));
+    }
+  } catch (err) {
+    console.error('Error copying assets:', err);
+  }
+
+  console.log(`${browser} bundle generated at ${outDir}`);
+}
+
+const target = process.argv[2];
+if (target === 'chrome') generateManifestFor('chrome');
+else if (target === 'firefox') generateManifestFor('firefox');
+else {
+  generateManifestFor('chrome');
+  generateManifestFor('firefox');
+}


### PR DESCRIPTION
This PR adds a small manifest generation utility and the accompanying documentation and package.json scripts,
to add firefox compatibility #2 

- Adds `scripts/generate-manifest.js` which copies `icons/` and `src/` into `dist/<browser>/` and prepares browser bundles.
- Adds npm scripts: `manifest:chrome`, `manifest:firefox`, `manifest:all`.
- Updates `.gitignore` to exclude generated `dist/`, `.env`, and `.DS_Store`.
- Updates `README.md` with usage instructions for generating browser bundles.


Files changed (summary)
-----------------------

- Added: `scripts/generate-manifest.js` — a simple Node script to copy icons and `src/` into `dist/<browser>/` and produce browser-specific manifests.
- Modified: `.gitignore` — ignore `.env`, `dist/`, and macOS `.DS_Store`.
- Modified: `README.md` — added instructions for using the new manifest generation scripts.
- Modified: `package.json` — added npm scripts: `manifest:chrome`, `manifest:firefox`, and `manifest:all`.

Detailed per-file notes
-----------------------

1) scripts/generate-manifest.js (new)

- Purpose: generate browser-specific bundles into `dist/` by copying `icons/` and `src/` and generating the appropriate manifest structure.
- Location: `scripts/generate-manifest.js`
- Status: added (staged).
- Quick test: `node scripts/generate-manifest.js chrome` should create `dist/chrome/` with expected files.

2) .gitignore (modified)

- Added lines:
	- `.env`
	- `dist/`
	- `.DS_Store`

Rationale: `dist/` is generated output from the manifest generator; `.env` and `.DS_Store` are common local/OS files we don't want in version control.

3) README.md (modified)

- Added a short section titled "Building browser bundles (manifests)" that documents how to run the generator via npm scripts:

	- `npm run manifest:chrome`
	- `npm run manifest:firefox`
	- `npm run manifest:all`

Rationale: Makes it easier for contributors to create browser-specific artifacts.

4) package.json (modified)

- Added npm scripts:
	- `manifest:chrome` -> `node scripts/generate-manifest.js chrome`
	- `manifest:firefox` -> `node scripts/generate-manifest.js firefox`
	- `manifest:all` -> `node scripts/generate-manifest.js`

Rationale: provide convenient shortcuts for running the generator.

How to test locally
--------------------

1. Generate a Chrome bundle:

```bash
npm run manifest:chrome
```

2. Verify `dist/chrome/` contains `icons/`, `src/`, and a manifest suitable for Chrome.

3. Generate Firefox bundle:

```bash
npm run manifest:firefox
```

4. Inspect the generated files or load the `dist/<browser>/` directory as an unpacked extension in your browser for a quick smoke test.

