### PR TITLE
fix: update course name retrieval to use textContent instead of title

### DIFF
--- a/src/content/content_script.js
+++ b/src/content/content_script.js
@@ -384,7 +384,7 @@ async function renderWPStartCourseBtn({ signal }) {
             state.courseImgSrc = await imgSrcToBase64(playlistItems.querySelector("img")?.src);
             state.courseName = document.querySelector(
                 "#playlist:not([hidden]) #header-contents .title"
-            ).title;
+            ).textContent;
             setToStorage();
             showToast("Course Started");
         } catch (err) {


### PR DESCRIPTION
fixes Course names not recording
Fixes #31

<img width="896" height="88" alt="image" src="https://github.com/user-attachments/assets/146ed726-6fbc-4550-8310-232790473d4f" />
