### PR TITLE
fix: update selector for playlist name element in content script

### DIFF
--- a/src/content/content_script.js
+++ b/src/content/content_script.js
@@ -23,7 +23,7 @@ const SELECTORS = {
         courseTextEl: ".metadata-wrapper badge-shape",
         playlistTextEl: ".page-header-sidebar .yt-content-metadata-view-model__metadata-text",
         playlistNameEl:
-            "ytd-browse[page-subtype=playlist] > yt-page-header-renderer .yt-page-header-view-model__page-header-headline-info yt-dynamic-text-view-model span",
+            "ytd-browse[page-subtype=playlist] > yt-page-header-renderer .yt-page-header-view-model__page-header-headline-info yt-dynamic-text-view-model h1 span",
         recommendations: "ytd-watch-next-secondary-results-renderer",
 
         ytCourse: {


### PR DESCRIPTION
The problem was, some extensions (eg: youtube to notebooklm) add other tags
So by adding the h1 tag it will be future proof

Fixes #31