### PR TITLE
feat: add remaining course duration tracker

### DIFF
--- a/src/content/content_script.js
+++ b/src/content/content_script.js
@@ -653,10 +653,12 @@ async function renderWPProgressDiv({ signal }) {
     const totalTime = document.createElement("div");
     totalTime.id = "total-time";
     totalTime.textContent = `${state.totalDuration.hours}h ${state.totalDuration.minutes}m ${state.totalDuration.seconds}s`;
+    
+    const remainingTime = document.createElement("div");
+    remainingTime.id = "remaining-time";
+    remainingTime.innerHTML = `<b>Left:</b> ${getRemainingDurationStr()}`;
 
-    // Append to time container
-    timeContainer.append(watchedTime, completedVideos, totalTime);
-
+    timeContainer.append(watchedTime, completedVideos, totalTime, remainingTime);
     // Progress bar
     const progressBarOuter = document.createElement("div");
     progressBarOuter.className = "progress-bar-outer-container";
@@ -814,6 +816,22 @@ async function renderPPProgressDiv({ signal }) {
     watchedSvg.setAttribute("stroke-width", "2");
     watchedSvg.innerHTML = `<circle cx="12" cy="12" r="10"></circle>
                             <path d="M8.5 12.5L11 15l5-5.5" stroke-linecap="round" stroke-linejoin="round"></path>`;
+    const remainingDiv = document.createElement("div");
+    remainingDiv.className = "tmc-remaining";
+
+    const remainingSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    remainingSvg.setAttribute("width", "16");
+    remainingSvg.setAttribute("height", "16");
+    remainingSvg.setAttribute("viewBox", "0 0 24 24");
+    remainingSvg.setAttribute("fill", "none");
+    remainingSvg.setAttribute("stroke", "currentColor");
+    remainingSvg.setAttribute("stroke-width", "2");
+    remainingSvg.innerHTML = `<circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline>`;
+
+    const remainingText = document.createElement("span");
+    remainingText.className = "tmc-remaining-text";
+    remainingText.textContent = `Left: ${getRemainingDurationStr()}`;
+    remainingDiv.append(remainingSvg, remainingText);
 
     const watchedText = document.createElement("span");
     watchedText.className = "tmc-watched-text";
@@ -843,7 +861,7 @@ async function renderPPProgressDiv({ signal }) {
     </svg>`;
 
     actionsDiv.append(refreshDiv, deleteDiv);
-    wrapper.append(totalDiv, durationDiv, watchedDiv, actionsDiv);
+    wrapper.append(totalDiv, durationDiv, watchedDiv, remainingDiv, actionsDiv);
 
     // Delete popup
     const deletePopup = document.createElement("div");
@@ -1004,6 +1022,10 @@ function refreshWatchPageUI({ signal }) {
         `${state.watchedDuration.hours}h ${state.watchedDuration.minutes}m ${state.watchedDuration.seconds}s`;
     progressDiv.querySelector("#total-time").textContent =
         `${state.totalDuration.hours}h ${state.totalDuration.minutes}m ${state.totalDuration.seconds}s`;
+    const remainingTimeEl = progressDiv.querySelector("#remaining-time");
+    if (remainingTimeEl) {
+        remainingTimeEl.innerHTML = `<b>Left:</b> ${getRemainingDurationStr()}`;
+    }
     progressDiv.querySelector("#invested-time").textContent =
         `${state.investedTime.hours}h ${state.investedTime.minutes}m`;
 
@@ -1041,6 +1063,10 @@ function refreshPlaylistPageUI({ signal }) {
     } / ${Object.keys(state.videoWatchStatus).length} watched`;
 
     updateVideoCheckboxes(PAGE_TYPE.PLAYLIST);
+    const remainingTextEl = progressDiv.querySelector(".tmc-remaining-text");
+    if (remainingTextEl) {
+        remainingTextEl.textContent = `Left: ${getRemainingDurationStr()}`;
+    }
 }
 
 function updateVideoCheckboxes(page) {
@@ -2007,4 +2033,11 @@ async function updateHomeCoursesContent({ signal } = {}) {
     for (const course of courses) {
         homeCoursesScroller.append(createCourseCard(course));
     }
+}
+function getRemainingDurationStr() {
+    const totalSec = durationToSeconds(state.totalDuration);
+    const watchedSec = durationToSeconds(state.watchedDuration);
+    const remainingSec = Math.max(0, totalSec - watchedSec); 
+    const rem = secondsToDuration(remainingSec);
+    return `${rem.hours}h ${rem.minutes}m ${rem.seconds}s`;
 }

--- a/src/content/content_script.js
+++ b/src/content/content_script.js
@@ -653,12 +653,10 @@ async function renderWPProgressDiv({ signal }) {
     const totalTime = document.createElement("div");
     totalTime.id = "total-time";
     totalTime.textContent = `${state.totalDuration.hours}h ${state.totalDuration.minutes}m ${state.totalDuration.seconds}s`;
-    
-    const remainingTime = document.createElement("div");
-    remainingTime.id = "remaining-time";
-    remainingTime.innerHTML = `<b>Left:</b> ${getRemainingDurationStr()}`;
 
-    timeContainer.append(watchedTime, completedVideos, totalTime, remainingTime);
+    // Append to time container
+    timeContainer.append(watchedTime, completedVideos, totalTime);
+
     // Progress bar
     const progressBarOuter = document.createElement("div");
     progressBarOuter.className = "progress-bar-outer-container";
@@ -816,6 +814,16 @@ async function renderPPProgressDiv({ signal }) {
     watchedSvg.setAttribute("stroke-width", "2");
     watchedSvg.innerHTML = `<circle cx="12" cy="12" r="10"></circle>
                             <path d="M8.5 12.5L11 15l5-5.5" stroke-linecap="round" stroke-linejoin="round"></path>`;
+
+    const watchedText = document.createElement("span");
+    watchedText.className = "tmc-watched-text";
+    const watchedCount = Object.values(state.videoWatchStatus).filter(Boolean).length;
+    const totalCount = Object.keys(state.videoWatchStatus).length;
+    watchedText.textContent = `${watchedCount} / ${totalCount} watched`;
+
+    watchedDiv.append(watchedSvg, watchedText);
+
+    // Remaining
     const remainingDiv = document.createElement("div");
     remainingDiv.className = "tmc-remaining";
 
@@ -833,14 +841,7 @@ async function renderPPProgressDiv({ signal }) {
     remainingText.textContent = `Left: ${getRemainingDurationStr()}`;
     remainingDiv.append(remainingSvg, remainingText);
 
-    const watchedText = document.createElement("span");
-    watchedText.className = "tmc-watched-text";
-    const watchedCount = Object.values(state.videoWatchStatus).filter(Boolean).length;
-    const totalCount = Object.keys(state.videoWatchStatus).length;
-    watchedText.textContent = `${watchedCount} / ${totalCount} watched`;
-
-    watchedDiv.append(watchedSvg, watchedText);
-
+    // Actions (Refresh & Delete)
     const actionsDiv = document.createElement("div");
     actionsDiv.className = "tmc-actions";
 
@@ -1022,10 +1023,6 @@ function refreshWatchPageUI({ signal }) {
         `${state.watchedDuration.hours}h ${state.watchedDuration.minutes}m ${state.watchedDuration.seconds}s`;
     progressDiv.querySelector("#total-time").textContent =
         `${state.totalDuration.hours}h ${state.totalDuration.minutes}m ${state.totalDuration.seconds}s`;
-    const remainingTimeEl = progressDiv.querySelector("#remaining-time");
-    if (remainingTimeEl) {
-        remainingTimeEl.innerHTML = `<b>Left:</b> ${getRemainingDurationStr()}`;
-    }
     progressDiv.querySelector("#invested-time").textContent =
         `${state.investedTime.hours}h ${state.investedTime.minutes}m`;
 
@@ -1062,11 +1059,10 @@ function refreshPlaylistPageUI({ signal }) {
         Object.values(state.videoWatchStatus).filter(Boolean).length
     } / ${Object.keys(state.videoWatchStatus).length} watched`;
 
+    progressDiv.querySelector(".tmc-remaining-text").textContent =
+        `Left: ${getRemainingDurationStr()}`;
+
     updateVideoCheckboxes(PAGE_TYPE.PLAYLIST);
-    const remainingTextEl = progressDiv.querySelector(".tmc-remaining-text");
-    if (remainingTextEl) {
-        remainingTextEl.textContent = `Left: ${getRemainingDurationStr()}`;
-    }
 }
 
 function updateVideoCheckboxes(page) {
@@ -2037,7 +2033,7 @@ async function updateHomeCoursesContent({ signal } = {}) {
 function getRemainingDurationStr() {
     const totalSec = durationToSeconds(state.totalDuration);
     const watchedSec = durationToSeconds(state.watchedDuration);
-    const remainingSec = Math.max(0, totalSec - watchedSec); 
+    const remainingSec = Math.max(0, totalSec - watchedSec);
     const rem = secondsToDuration(remainingSec);
     return `${rem.hours}h ${rem.minutes}m ${rem.seconds}s`;
 }

--- a/src/styles/playlistPage.css
+++ b/src/styles/playlistPage.css
@@ -53,14 +53,13 @@
     padding: 6px 12px;
     border-radius: 8px;
 }
-.tmc-pp-progress-div .tmc-remaining {  
+.tmc-pp-progress-div .tmc-remaining {
     display: flex;
+    flex-basis: 100%;
     align-items: center;
     gap: 5px;
     font-size: 14px;
     height: 20px;
-    grid-column: span 3;
-    
 }
 .tmc-pp-progress-div .tmc-actions {
     border-radius: 8px 0px 8px 0;

--- a/src/styles/playlistPage.css
+++ b/src/styles/playlistPage.css
@@ -53,6 +53,15 @@
     padding: 6px 12px;
     border-radius: 8px;
 }
+.tmc-pp-progress-div .tmc-remaining {  
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 14px;
+    height: 20px;
+    grid-column: span 3;
+    
+}
 .tmc-pp-progress-div .tmc-actions {
     border-radius: 8px 0px 8px 0;
     border-width: 1px 0px 0px 1px;


### PR DESCRIPTION
**Description:**

### Summary
This PR adds a "Remaining Time" feature to the progress UI on both the Watch Page and Playlist Page, allowing users to instantly see how much time is left to complete a course.

### Key Changes
* **Helper Logic:** Added `getRemainingDurationStr()` to calculate the difference between total and watched duration.
* **UI Updates:** Injected the remaining time element into both `renderWPProgressDiv` and `renderPPProgressDiv`, ensuring dynamic updates when videos are checked/unchecked.
* **Styling:** Updated `playlistPage.css` to align the new pill indicator with the existing UI.
### Screenshots
<img width="488" height="654" alt="image" src="https://github.com/user-attachments/assets/d7869c9a-dc2c-4fc6-a541-09d7d942e991" />
<img width="1882" height="927" alt="image" src="https://github.com/user-attachments/assets/d418233a-95f6-44da-bf2d-d53810eef100" />
<img width="1879" height="869" alt="image" src="https://github.com/user-attachments/assets/84a82509-3771-44e9-a69b-fa818fbbfeae" />

### Testing Done
* Built via `npm run build:chrome` and loaded unpacked.
* Verified the UI matches existing styling on both pages.
* Verified the remaining time decreases/increases dynamically when toggling video checkmarks.
